### PR TITLE
Fix SetLODs error when model has the own lod group

### DIFF
--- a/Scripts/Editor/ModelImporterLODGenerator.cs
+++ b/Scripts/Editor/ModelImporterLODGenerator.cs
@@ -243,7 +243,7 @@ namespace UnityEditor.Experimental.AutoLOD
                     var screenPercentage = i == maxLODFound ? 0.01f : Mathf.Pow(0.5f, i + 1);
 
                     // Use the model importer percentages if they exist
-                    if (i < importerLODLevels.arraySize)
+                    if (i < importerLODLevels.arraySize && maxLODFound == importerLODLevels.arraySize)
                     {
                         var element = importerLODLevels.GetArrayElementAtIndex(i);
                         screenPercentage = element.floatValue;
@@ -251,6 +251,11 @@ namespace UnityEditor.Experimental.AutoLOD
 
                     lod.screenRelativeTransitionHeight = screenPercentage;
                     lods.Add(lod);
+                }
+
+                if (importerLODLevels.arraySize != 0 && maxLODFound != importerLODLevels.arraySize)
+                {
+                    Debug.LogWarning("The model has the own lod group but it will not be used because the specified lod count in settings is different.");
                 }
 
                 var lodGroup = go.AddComponent<LODGroup>();


### PR DESCRIPTION
It happens when model has own lod group and the specified lod count in settings is different from lod count in model. So, SetLODs gives you this error: 
`SetLODs: Attempting to set LOD where the screen relative size is greater then or equal to a higher detail LOD level.
UnityEditor.AssetPostprocessingInternal:PostprocessMesh(GameObject)`

Maybe related to #13 