### PR TITLE
Ignore invalid scenes

### DIFF
--- a/Scripts/Editor/SceneLOD.cs
+++ b/Scripts/Editor/SceneLOD.cs
@@ -27,6 +27,7 @@ namespace Unity.AutoLOD
                         AssetDatabase.StartAssetEditing();
 
                         var scene = SceneManager.GetSceneByPath(path);
+                        if(!scene.IsValid()) continue;
                         var rootGameObjects = scene.GetRootGameObjects();
                         foreach (var go in rootGameObjects)
                         {


### PR DESCRIPTION
Currently there's an error when saving assets; this PR makes sure the error doesn't throw and assets are still saved.