### PR TITLE
Large model indexing

### DIFF
--- a/Scripts/Editor/AutoLOD.cs
+++ b/Scripts/Editor/AutoLOD.cs
@@ -526,6 +526,7 @@ namespace Unity.AutoLOD
                         EditorUtility.CopySerialized(mf.GetComponent<MeshRenderer>(), lodRenderer);
 
                         var simplifiedMesh = new Mesh();
+                        simplifiedMesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
                         simplifiedMesh.name = sharedMesh.name + string.Format(" LOD{0}", l);
                         lodMF.sharedMesh = simplifiedMesh;
                         meshes.Add(simplifiedMesh);

--- a/Scripts/Editor/MeshSimplifiers/MeshDecimatorSimplifier.cs
+++ b/Scripts/Editor/MeshSimplifiers/MeshDecimatorSimplifier.cs
@@ -32,7 +32,6 @@ namespace Unity.AutoLOD
             int targetTriangleCount = Mathf.CeilToInt(totalTriangleCount * quality);
 
             var algorithm = MeshDecimation.CreateAlgorithm(Algorithm.Default);
-            algorithm.KeepLinkedVertices = false;
 
             DecimationAlgorithm.StatusReportCallback statusCallback = (iteration, tris, currentTris, targetTris) =>
             {

--- a/Scripts/Editor/ModelImporterLODGenerator.cs
+++ b/Scripts/Editor/ModelImporterLODGenerator.cs
@@ -97,6 +97,7 @@ namespace Unity.AutoLOD
                             var inputMesh = mf.sharedMesh;
 
                             var outputMesh = new Mesh();
+                            outputMesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
                             outputMesh.name = inputMesh.name;
                             outputMesh.bounds = inputMesh.bounds;
                             mf.sharedMesh = outputMesh;
@@ -140,6 +141,7 @@ namespace Unity.AutoLOD
                             AppendLODNameToRenderer(lodRenderer, i);
 
                             var outputMesh = new Mesh();
+                            outputMesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
                             outputMesh.name = string.Format("{0} LOD{1}", inputMesh.name, i);
                             outputMesh.bounds = inputMesh.bounds;
                             lodMF.sharedMesh = outputMesh;
@@ -195,7 +197,6 @@ namespace Unity.AutoLOD
 
                             return false;
                         });
-
                         // Process remaining meshes
                         foreach (var ml in meshLODs)
                         {

--- a/Scripts/Helpers/MeshLOD.cs
+++ b/Scripts/Helpers/MeshLOD.cs
@@ -78,8 +78,10 @@ namespace Unity.AutoLOD
             var inputMesh = InputMesh;
             job.InputMesh = inputMesh.ToWorkingMesh(Allocator.Persistent);
             job.Quality = Quality;
-            job.OutputMesh = new WorkingMesh(Allocator.Persistent, inputMesh.vertexCount, inputMesh.GetTriangleCount(),
+            var workingMesh = new WorkingMesh(Allocator.Persistent, inputMesh.vertexCount, inputMesh.GetTriangleCount(),
                 inputMesh.subMeshCount, inputMesh.blendShapeCount);
+            workingMesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            job.OutputMesh = workingMesh;
 
             JobHandle jobHandle;
             if (jobDependencies.HasValue)


### PR DESCRIPTION
Larger models require indexing beyond 16-bit integers. This change defaults all temporary and working meshes to 32-bit so that we don't run into problems when there are more than 65535 vertices.