### PR TITLE
Fixed AssetDatabase.Start/StopAssetEditing

### DIFF
--- a/Editor/SceneLOD.cs
+++ b/Editor/SceneLOD.cs
@@ -22,21 +22,26 @@ namespace Unity.AutoLOD
             {
                 foreach (string path in paths)
                 {
-                    if (path.Contains(".unity"))
+                    if (path.EndsWith(".unity"))
                     {
-                        AssetDatabase.StartAssetEditing();
-
                         var scene = SceneManager.GetSceneByPath(path);
                         if(!scene.IsValid()) continue;
-                        var rootGameObjects = scene.GetRootGameObjects();
-                        foreach (var go in rootGameObjects)
-                        {
-                            var lodVolume = go.GetComponent<LODVolume>();
-                            if (lodVolume)
-                                PersistHLODs(lodVolume, path);
-                        }
 
-                        AssetDatabase.StopAssetEditing();
+                        try
+                        {
+                            AssetDatabase.StartAssetEditing();
+                            var rootGameObjects = scene.GetRootGameObjects();
+                            foreach (var go in rootGameObjects)
+                            {
+                                var lodVolume = go.GetComponent<LODVolume>();
+                                if (lodVolume)
+                                    PersistHLODs(lodVolume, path);
+                            }
+                        }
+                        finally
+                        {
+                            AssetDatabase.StopAssetEditing();
+                        }
                     }
                 }
  

--- a/Editor/SceneLOD.cs
+++ b/Editor/SceneLOD.cs
@@ -27,9 +27,9 @@ namespace Unity.AutoLOD
                         var scene = SceneManager.GetSceneByPath(path);
                         if(!scene.IsValid()) continue;
 
+                        AssetDatabase.StartAssetEditing();
                         try
                         {
-                            AssetDatabase.StartAssetEditing();
                             var rootGameObjects = scene.GetRootGameObjects();
                             foreach (var go in rootGameObjects)
                             {


### PR DESCRIPTION
1. For some reason the Start/Stop asset editing calls were not setup correctly in the scene post processor. This issue completely breaks asset bundle builds.

2. The ".unity" check should only check if the file "EndsWith" the extension, not contains. I could have a prefab named "MyPrefab.unity.prefab".