### PR TITLE
Set "false" by default for Generate on import

### DIFF
--- a/Editor/AutoLOD.cs
+++ b/Editor/AutoLOD.cs
@@ -104,7 +104,7 @@ namespace Unity.AutoLOD
                 EditorPrefs.SetBool(k_GenerateOnImport, value);
                 UpdateDependencies();
             }
-            get { return EditorPrefs.GetBool(k_GenerateOnImport, true); }
+            get { return EditorPrefs.GetBool(k_GenerateOnImport, false); }
         }
 
         static bool saveAssets


### PR DESCRIPTION
Fix issue https://github.com/Unity-Technologies/AutoLOD/issues/88

Tested on fresh project. It is false by default